### PR TITLE
⚙️ Config: Add addAllowedOrigin address

### DIFF
--- a/src/main/java/com/catlendar/config/SecurityConfig.java
+++ b/src/main/java/com/catlendar/config/SecurityConfig.java
@@ -51,6 +51,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.addAllowedOrigin("http://localhost:3000");
+        configuration.addAllowedOrigin("https://catlendar.netlify.app");
         configuration.addAllowedHeader("*");
         configuration.addAllowedMethod("*");
         configuration.setAllowCredentials(true);


### PR DESCRIPTION
cors 정책으로 인해 주어진 주소로만 api 접근이 가능하도록 해당 주소 추가
=> configuration.addAllowedOrigin("https://catlendar.netlify.app");
